### PR TITLE
Rename brightness() to setBrightness()

### DIFF
--- a/include/ledmatrix.h
+++ b/include/ledmatrix.h
@@ -52,12 +52,12 @@ class LedMatrix : public node::ObjectWrap
 	void DrawText	(int, int, std::tuple<int, int, int>, const char* text, const char* fontFile); 
 	void DrawCircle	(int, int, int, std::tuple<int, int, int>);
 	void DrawLine	(int, int, int, int, std::tuple<int, int, int>); 
-	void Brightness (int); 
+	void SetBrightness (int); 
 
 	void Update		(void);
 
 	protected:
-	LedMatrix (int rows , int cols , int chained_displays , int parallel_displays, int brightness, const char* mapping, const char* rgbSeq, std::vector<std::string> flags);
+	LedMatrix (int rows, int cols, int chained_displays , int parallel_displays, int brightness, const char* mapping, const char* rgbSeq, std::vector<std::string> flags);
 
 	virtual ~LedMatrix (void);
 
@@ -74,7 +74,7 @@ class LedMatrix : public node::ObjectWrap
 	static void DrawText		(const Nan::FunctionCallbackInfo<v8::Value>& args);
 	static void DrawCircle		(const Nan::FunctionCallbackInfo<v8::Value>& args);
 	static void DrawLine		(const Nan::FunctionCallbackInfo<v8::Value>& args);
-	static void Brightness		(const Nan::FunctionCallbackInfo<v8::Value>& args);
+	static void SetBrightness	(const Nan::FunctionCallbackInfo<v8::Value>& args);
 
 	static void Scroll			(const Nan::FunctionCallbackInfo<v8::Value>& args);
 	static void UV_Scroll		(uv_work_t* work);

--- a/src/ledmatrix.cc
+++ b/src/ledmatrix.cc
@@ -95,7 +95,7 @@ void LedMatrix::Init (v8::Local<v8::Object> exports)
 	Nan::SetPrototypeMethod(tpl, "drawText", DrawText);
 	Nan::SetPrototypeMethod(tpl, "drawCircle", DrawCircle);
 	Nan::SetPrototypeMethod(tpl, "drawLine", DrawLine);
-	Nan::SetPrototypeMethod(tpl, "brightness", Brightness);
+	Nan::SetPrototypeMethod(tpl, "setBrightness", SetBrightness);
 	
 	constructor.Reset(tpl->GetFunction());
 
@@ -365,20 +365,20 @@ void LedMatrix :: DrawLine   (const Nan::FunctionCallbackInfo<Value>& args)
 
 	return matrix->DrawLine( x0, y0, x1, y1, std::make_tuple(r, g, b));
 }
-void LedMatrix :: Brightness (int b)
+void LedMatrix :: SetBrightness (int b)
 {
 
 	matrix->SetBrightness(b);
 }
 
-void LedMatrix :: Brightness (const Nan::FunctionCallbackInfo<Value>& args)
+void LedMatrix :: SetBrightness (const Nan::FunctionCallbackInfo<Value>& args)
 {
 	LedMatrix* matrix = ObjectWrap::Unwrap<LedMatrix>(args.Holder()); 
 	int b = 100; 
 
 	b = args[0]->ToInteger()->Value();
 
-	return matrix->Brightness(b);
+	return matrix->SetBrightness(b);
 }
 
 


### PR DESCRIPTION
This proposed API change feels more consistent with the rest of the naming, and also the original API.