### PR TITLE
update to latest rpi-rgb-led-matrix

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,6 @@
 			"type": "static_library",
 			"sources": [
 
-			"./external/matrix/lib/transformer.cc",
 			"./external/matrix/lib/thread.cc",
 			"./external/matrix/lib/pixel-mapper.cc",
 			"./external/matrix/lib/options-initialize.cc",

--- a/include/ledmatrix.h
+++ b/include/ledmatrix.h
@@ -22,7 +22,6 @@
 #include <graphics.h>
 
 using namespace rgb_matrix;
-using rgb_matrix::GPIO;
 
 #define SCROLL_TO_LEFT 		0x01
 #define SCROLL_TO_RIGHT 	0x02
@@ -84,7 +83,6 @@ class LedMatrix : public node::ObjectWrap
 
 	private:
 
-	GPIO io;
 	RGBMatrix* matrix;
 	FrameCanvas* canvas;
 

--- a/src/ledmatrix.cc
+++ b/src/ledmatrix.cc
@@ -23,7 +23,6 @@
 using namespace v8;
 using namespace node;
 using namespace rgb_matrix;
-using rgb_matrix::GPIO;
 
 Nan::Persistent<Function> LedMatrix::constructor;
 std::map<std::string, rgb_matrix::Font> LedMatrix::fontMap;


### PR DESCRIPTION
I wanted to use some newer features of the rpi-rgb-led-matrix library namely V-mapper:Z so attempted to update the submodule.

Ran into a issue that https://github.com/hzeller/rpi-rgb-led-matrix/commit/3ea0f8369ab48d5a8ad802ad7c84ca2becabaccc breaks compliation. This is beyond me but removing 3 lines from 2 files made it compile and it works in my limited testing.

You will want to check it over and ensure that everything still works as I don't really know what I am doing here
